### PR TITLE
Support installation on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, rockylinux-8, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, rockylinux-8, debian-buster, debian-stretch]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ bravebrowser_app: brave-browser
 bravebrowser_app_desired_state: present
 
 # Debian family based
-bravebrowser_repo_debian_gpg_key: https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
-bravebrowser_repo_debian: "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main"
+bravebrowser_repo_debian_url: "https://brave-browser-apt-release.s3.brave.com"
+bravebrowser_repo_debian_gpg_key: brave-browser-archive-keyring.gpg
+bravebrowser_repo_debian_gpg_key_url: "{{ bravebrowser_repo_debian_url }}/{{ bravebrowser_repo_debian_gpg_key }}"
+bravebrowser_repo_debian_gpg_key_dest: "/usr/share/keyrings/{{ bravebrowser_repo_debian_gpg_key }}"
+bravebrowser_repo_debian: "deb [signed-by={{ bravebrowser_repo_debian_gpg_key_dest }} arch=amd64] {{ bravebrowser_repo_debian_url }} stable main"
 bravebrowser_repo_debian_filename: "{{ bravebrowser_app }}"
 bravebrowser_repo_debian_desired_state: present
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,8 +5,11 @@ bravebrowser_app: brave-browser
 bravebrowser_app_desired_state: present
 
 # Debian family based
-bravebrowser_repo_debian_gpg_key: https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
-bravebrowser_repo_debian: "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main"
+bravebrowser_repo_debian_url: "https://brave-browser-apt-release.s3.brave.com"
+bravebrowser_repo_debian_gpg_key: brave-browser-archive-keyring.gpg
+bravebrowser_repo_debian_gpg_key_url: "{{ bravebrowser_repo_debian_url }}/{{ bravebrowser_repo_debian_gpg_key }}"
+bravebrowser_repo_debian_gpg_key_dest: "/usr/share/keyrings/{{ bravebrowser_repo_debian_gpg_key }}"
+bravebrowser_repo_debian: "deb [signed-by={{ bravebrowser_repo_debian_gpg_key_dest }} arch=amd64] {{ bravebrowser_repo_debian_url }} stable main"
 bravebrowser_repo_debian_filename: "{{ bravebrowser_app }}"
 bravebrowser_repo_debian_desired_state: present
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
       versions:
         - bionic
         - focal
+        - jammy
     - name: Debian
       versions:
         - buster

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -14,6 +14,7 @@
     state: "{{ bravebrowser_repo_debian_desired_state }}"
     filename: "{{ bravebrowser_repo_debian_filename }}"
     update_cache: yes
+  become: true
 
 - name: Debian/Ubuntu Family | Installing {{ bravebrowser_app }}
   ansible.builtin.apt:
@@ -21,3 +22,4 @@
     state: "{{ bravebrowser_app_desired_state }}"
     force_apt_get: yes
     update_cache: yes
+  become: true

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -2,19 +2,21 @@
 # tasks file for bravebrowser - Debian/Ubuntu family
 
 - name: Debian/Ubuntu Family | Add gpg signing key for {{ bravebrowser_app }}
-  apt_key:
-    url: "{{ bravebrowser_repo_debian_gpg_key }}"
-    state: present
+  ansible.builtin.get_url:
+    url: "{{ bravebrowser_repo_debian_gpg_key_url }}"
+    dest: "{{ bravebrowser_repo_debian_gpg_key_dest }}"
+    mode: "0644"
+  become: true
 
-- name: Debian/Ubuntu Family | Adding repository "{{ bravebrowser_repo_debian }}"
-  apt_repository:
+- name: "Debian/Ubuntu Family | Adding repository {{ bravebrowser_repo_debian }}"
+  ansible.builtin.apt_repository:
     repo: "{{ bravebrowser_repo_debian }}"
     state: "{{ bravebrowser_repo_debian_desired_state }}"
     filename: "{{ bravebrowser_repo_debian_filename }}"
     update_cache: yes
 
 - name: Debian/Ubuntu Family | Installing {{ bravebrowser_app }}
-  apt:
+  ansible.builtin.apt:
     name: "{{ bravebrowser_app }}"
     state: "{{ bravebrowser_app_desired_state }}"
     force_apt_get: yes


### PR DESCRIPTION
I had several issues when using this role with ubuntu 22.04:
1) Adding the brave repo gpg key used the deprecated add-key function -> Fix addition of gpg key
2) When adding the repository to the list, apt fails to verify the signature (`The following signatures couldn't be verified because the public key is not available`) -> Fix adding repository while specifying signing key

With this PR the Debian install tasks exactly mirror the instructions mentioned at https://brave.com/linux/
I tested that things work as expected using `DISTRO="ubuntu-22.04" molecule converge`